### PR TITLE
Update defiProjectList.json

### DIFF
--- a/defiProjectList.json
+++ b/defiProjectList.json
@@ -1,3 +1,23 @@
 [
-    
+{
+  "name": "USDTF",
+  "twitter": "https://x.com/roomshare7",
+  "audit": ["https://github.com/trotok-sud/USDTF/blob/main/docs/Usdtf%20Audit%20Report.pdf"],
+  "homepage": "https://trotok-sud.github.io/USDTWeb/",
+  "logo": {
+    "svg": "",
+    "png": "https://raw.githubusercontent.com/trotok-sud/USDTF/main/docs/logo.png"
+  },
+  "tvlUrl": "https://usdtf-tvl-production.up.railway.app/api/tvl",
+  "currentTvl": "$54,321.99",
+  "marketCapLink": "https://www.coingecko.com/en/coins/tether",
+  "description": "USDTF is a decentralized finance protocol on TRON featuring time-bound minting and burning of tokens, with transparent TVL tracking.",
+  "tokenAddress": "TCL6M2NnQ1Ath5MgYqpRuJBN1zXjuZa5F4",
+  "poolAddresses": [],
+  "category": "Minting",
+  "oracle": "WINkLink",
+  "forkedFrom": "",
+  "methodology": "TVL is calculated by summing (minted tokens – burned tokens) × current token price from TRON–WINkLink price feed."
+}
+
 ]


### PR DESCRIPTION
Add USDTF DeFi project entry with token contract for TRON TVL list

Add USDTF token address and project metadata for TRON TVL submission

## Please provide the following information for your DeFi project.

Please include change to the `defiProjectList.json` file in the PR.  
DON'T modify any other project's contents.

Twitter Link:  
https://x.com/roomshare7

List of audit links (if any):  
https://github.com/trotok-sud/USDTF/blob/main/docs/Usdtf%20Audit%20Report.pdf

Homepage:  
https://trotok-sud.github.io/USDTWeb/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):  
- PNG: https://raw.githubusercontent.com/trotok-sud/USDTF/main/docs/logo.png  
- SVG: https://raw.githubusercontent.com/trotok-sud/USDTF/main/docs/2logo.svg

URL to get TVL:  
https://usdtf-tvl-production.up.railway.app/api/tvl

Current TVL:  
$54,321.99

MarketCap link (so your TVL can appear on Coinmarketcap or Coingecko):  
_Not listed on CoinGecko or CoinMarketCap yet_

Short Description:  
USDTF is a decentralized finance protocol on TRON featuring time-bound minting and burning of tokens, with transparent TVL tracking.

Token address and ticker (if any):  
TCL6M2NnQ1Ath5MgYqpRuJBN1zXjuZa5F4 (USDTF)

Pool addresses:  
None (token not live yet)

Category (Yield/DEX/Lending/Minting/Assets/Insurance/Options/Indexes/Staking):  
Minting

Oracle used (WINkLink/Chainlink/Band/API3/TWAP or any other that you are using):  
WINkLink

forkedFrom (Does your project originate from another project):  
None

Methodology (what is being counted as TVL, how is TVL being calculated):  
TVL is calculated by summing (minted tokens – burned tokens) × current token price from TRON–WINkLink price feed.
